### PR TITLE
Fix issue with forked branches

### DIFF
--- a/.github/workflows/readme-list-update.yml
+++ b/.github/workflows/readme-list-update.yml
@@ -1,7 +1,7 @@
 name: Update Examples List in README
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -16,7 +16,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -31,7 +32,6 @@ jobs:
             cat error.log
             exit 1
           fi
-
       - name: Commit changes
         if: success()
         run: |
@@ -39,7 +39,6 @@ jobs:
           git config --local user.name "GitHub Action"
           git add README.md
           git commit -m "Update README.md with new examples and technologies" || echo "No changes to commit"
-
       - name: Push changes
         if: success()
         run: git push origin ${{ github.head_ref }}
@@ -54,7 +53,6 @@ jobs:
           -X POST \
           -d '{"body": "🚨 **README Update Failed**\n\nThe following tech stack(s) were found in examples but do not have entries in `techs.json`. Please add each missing tech in `techs.json` with the following format:\n\n```json\n\"tech-id\": \"Tech Display Name\"\n```\n\nFor example:\n\n```json\n\"nextjs\": \"Next.js\"\n```\n\nMissing Tech(s):\n\n```\n'"$tech_error"'\n```"}' \
           "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments")
-
           if [ "$response" -eq 201 ]; then
             echo "Comment posted successfully."
           else


### PR DESCRIPTION
This PR fixes the problem pointed out by @bradgarropy at https://github.com/cloudinary-community/cloudinary-examples/pull/187#issuecomment-2516095076

The problem was that in pull requests, branches from forked repositories could not be checked out